### PR TITLE
PB-beta-v1.4.2

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,13 +1,14 @@
-- comments in sections disrupt the hotkey jumps
-- hotkey jumps don't loop
-- 1 to 182 trying to recolor tongue did not work, check keyballs data
-- fix mirror project to also change others
-- quick mirror all lock all on project mode
-- if applyling paintballz, then unselect first
-- be able to change the head rotation
-- render option draw paintballz -- do not hide the irises
-- frame number doesn't copy right when entering into animation frame? or just frame isnt captured right? -1?
-- Quick flash with CTRL+Q does not affect addballz
-- Add texture color to recolor menu
-- Links in Options Menu -> Help open both URLs at once
-- Scale up overshoots size
+2025-09-01
+
+- [ ]  Comments in sections disrupt the hotkey jumps
+- [ ]  Hotkey jumps don't loop
+- [ ]  Fix mirror project to propogate Fixed <> Projected pair swaps
+- [ ]  Clicking headers for Mirror and Lock should set/unset all in Project Mode
+- [ ]  If applyling paintballz, then unselect from Text Editor first, otherwise it replaces all
+- [ ]  Render option draw paintballz hides the irises but not on reload of LNZ
+- [ ]  Frame number doesn't copy right when entering into animation frame? or just frame isnt captured right? -1?
+- [ ]  Quick flash with CTRL+Q does not affect addballz
+- [ ]  Add texture color to recolor menu
+- [ ]  Links in Options Menu -> Help open both URLs at once
+- [ ]  Scale up overshoots size
+- [x]  Parse species from `[Default Linez File]` for breed file LNZ, if not `[Species]` as in pet file LNZ

--- a/data_classes/lnz_parser.gd
+++ b/data_classes/lnz_parser.gd
@@ -126,10 +126,30 @@ func get_species(file: File):
 	get_next_section(file, "Species")
 	var parsed_lines = get_parsed_lines(file, ["species"])
 	if parsed_lines.size() == 0:
-		species = 2
+		print("[Species] not found. Looking for [Default Linez File] as a fallback.")
+		file.seek(0)
+		get_next_section(file, "Default Linez File")
+		var path_line = file.get_line().strip_edges()
+		var lower_path = path_line.to_lower()
+		if "dog" in lower_path:
+			print("[Default Linez File] path contained 'dog'. Setting species to Dogz (Species = 2).")
+			species = 2
+		elif "cat" in lower_path:
+			print("[Default Linez File] path contained 'cat'. Setting species to Catz (Species = 1).")
+			species = 1
+		else:
+			print("Could not determine species from file. Defaulting to Catz (Species = 1).")
+			species = 1
 	else:
 		species = parsed_lines[0].species
-	# print("Species detected: " + str(species))
+		if species == 1:
+			print("[Species] detected: Catz (Species = " + str(species) + ")")
+		elif species == 2:
+			print("[Species] detected: Dogz (Species = " + str(species) + ")")
+		elif species == 3:
+			print("[Species] detected: Babyz (Species = " + str(species) + ")")
+		else:
+			print("[Species] detected: ??? (Species = " + str(species) + ")")		
 
 func get_texture_list(file: File):
 	get_next_section(file, "Texture List")

--- a/scenes/editor/LnzTextEdit.gd
+++ b/scenes/editor/LnzTextEdit.gd
@@ -2018,165 +2018,160 @@ func _on_ToolsMenu_recolor(all_recolor_info: Dictionary):
 
 	if all_recolor_info.balls_on or all_recolor_info.ball_outlines_on:
 		var section_find = search('[Ballz Info]', 0, 0, 0)
-		var start_of_section = section_find[SEARCH_RESULT_LINE] + 1
-		var i = 0
-		while true:
-			if i in balls_to_exclude:
-				i += 1
-				continue
-			var line = get_line(start_of_section + i).lstrip(" ")
-			if line.begins_with("[") or i > get_line_count():
-				break
-			if line.begins_with(";") or line.empty():
-				i += 1
-				continue
-			# here the first number is color and second is outline col
-			
-			# var parsed_line = r.search_all(line)
-			var delimiters = [", ", ",", "\t", " "]
-			var parsed_line = []
-			for delim in delimiters:
-				if line.split(delim).size() > 2:
-					parsed_line = line.split(delim, false)
-					break
+		if section_find:
+			var start_of_section = section_find[SEARCH_RESULT_LINE] + 1
+			var i = 0
+			while true:
+				var current_line_num = start_of_section + i
+				if current_line_num >= get_line_count(): break
+				
+				var line = get_line(current_line_num)
+				if line.begins_with("["): break
 
-			var color = parsed_line[0]
-			var outline_color = parsed_line[1]
-			if (recolor_info.has(color) and all_recolor_info.balls_on) or (recolor_info.has(outline_color) and all_recolor_info.ball_outlines_on):
-				var n = 0
-				var final_line = ""
-				for r_item in parsed_line:
-					var item = r_item
-					if n == 0 and recolor_info.has(item) and all_recolor_info.balls_on:
-						final_line += recolor_info[color] + " "
-					elif n == 1 and recolor_info.has(item) and all_recolor_info.ball_outlines_on:
-						final_line += recolor_info[outline_color] + " "
-					else:
-						final_line += item + " "
-					n += 1
-				set_line(start_of_section + i, final_line)
-			i += 1
-		
-		section_find = search('[Add Ball]', 0, 0, 0)
-		start_of_section = section_find[SEARCH_RESULT_LINE] + 1
-		i = 0
-		while true:
-			if i + KeyBallsData.max_base_ball_num in balls_to_exclude:
-				i += 1
-				continue
-			var line = get_line(start_of_section + i).lstrip(" ")
-			if line.begins_with("[") or i > get_line_count():
-				break
-			if line.begins_with(";") or line.empty():
-				i += 1
-				continue
-			# here the fifth number is color
+				if i in balls_to_exclude or line.lstrip(" ").begins_with(";") or line.strip_edges().empty():
+					i += 1
+					continue
 
-			# var parsed_line = r.search_all(line)
-			var delimiters = [", ", ",", "\t", " "]
-			var parsed_line = []
-			for delim in delimiters:
-				if line.split(delim).size() > 2:
-					parsed_line = line.split(delim, false)
-					break
+				var delimiter = _detect_delimiter(current_line_num, current_line_num + 1)
+				var parsed_line = _split_and_clean(line, delimiter)
+				
+				if parsed_line.size() < 2:
+					i += 1
+					continue
+				
+				var color = parsed_line[0]
+				var outline_color = parsed_line[1]
+				var updates = {}
+				
+				if all_recolor_info.balls_on and recolor_info.has(color):
+					updates[0] = recolor_info[color]
+				
+				if all_recolor_info.ball_outlines_on and recolor_info.has(outline_color):
+					updates[1] = recolor_info[outline_color]
+				
+				if not updates.empty():
+					var final_line = _update_fields(parsed_line, updates, delimiter)
+					set_line(current_line_num, final_line)
+				
+				i += 1
 
-			if parsed_line.size() == 0 or int(parsed_line[0]) in balls_to_exclude:
-				i += 1
-				continue
-			var color = parsed_line[4]
-			var outline_color = parsed_line[5]
-			if (recolor_info.has(color) and all_recolor_info.balls_on) or (recolor_info.has(outline_color) and all_recolor_info.ball_outlines_on):
-				var n = 0
-				var final_line = ""
-				for r_item in parsed_line:
-					var item = r_item
-					if n == 4 and recolor_info.has(item) and all_recolor_info.balls_on:
-						final_line += recolor_info[color] + " "
-					elif n == 5 and recolor_info.has(item) and all_recolor_info.ball_outlines_on:
-						final_line += recolor_info[outline_color] + " "
-					else:
-						final_line += item + " "
-					n += 1
-				set_line(start_of_section + i, final_line)
-			i += 1
-			
-	if all_recolor_info.paintballs_on:
-		var section_find = search('[Paint Ballz]', 0, 0, 0)
-		var start_of_section = section_find[SEARCH_RESULT_LINE] + 1
-		var i = 0
-		while true:
-			if i + KeyBallsData.max_base_ball_num in balls_to_exclude:
-				i += 1
-				continue
-			var line = get_line(start_of_section + i).lstrip(" ")
-			if line.begins_with("[") or i > get_line_count():
-				break
-			if line.begins_with(";") or line.empty():
-				i += 1
-				continue
-			# here the sixth number is color
+	if all_recolor_info.paintballs_on or all_recolor_info.balls_on or all_recolor_info.ball_outlines_on:
+		var addball_find = search('[Add Ball]', 0, 0, 0)
+		var paintball_find = search('[Paint Ballz]', 0, 0, 0)
 
-			# var parsed_line = r.search_all(line)
-			var delimiters = [", ", ",", "\t", " "]
-			var parsed_line = []
-			for delim in delimiters:
-				if line.split(delim).size() > 2:
-					parsed_line = line.split(delim, false)
-					break
+		if addball_find and (all_recolor_info.balls_on or all_recolor_info.ball_outlines_on):
+			var start_of_section = addball_find[SEARCH_RESULT_LINE] + 1
+			var i = 0
+			while true:
+				var current_line_num = start_of_section + i
+				if current_line_num >= get_line_count(): break
+				
+				var line = get_line(current_line_num)
+				if line.begins_with("["): break
+				
+				if line.lstrip(" ").begins_with(";") or line.strip_edges().empty():
+					i += 1
+					continue
 
-			if parsed_line.size() == 0 or int(parsed_line[0]) in balls_to_exclude:
+				var delimiter = _detect_delimiter(current_line_num, current_line_num + 1)
+				var parsed_line = _split_and_clean(line, delimiter)
+				
+				if parsed_line.size() < 6 or int(parsed_line[0]) in balls_to_exclude:
+					i += 1
+					continue
+				
+				var color = parsed_line[4]
+				var outline_color = parsed_line[5]
+				var updates = {}
+				
+				if all_recolor_info.balls_on and recolor_info.has(color):
+					updates[4] = recolor_info[color]
+				
+				if all_recolor_info.ball_outlines_on and recolor_info.has(outline_color):
+					updates[5] = recolor_info[outline_color]
+
+				if not updates.empty():
+					var final_line = _update_fields(parsed_line, updates, delimiter)
+					set_line(current_line_num, final_line)
+				
 				i += 1
-				continue
-			var color = parsed_line[5]
-			if recolor_info.has(color):
-				var n = 0
-				var final_line = ""
-				for r_item in parsed_line:
-					var item = r_item
-					if n == 5:
-						final_line += recolor_info[color] + " "
-					else:
-						final_line += item + " "
-					n += 1
-				set_line(start_of_section + i, final_line)
-			i += 1
-		
+
+		if paintball_find and all_recolor_info.paintballs_on:
+			var start_of_section = paintball_find[SEARCH_RESULT_LINE] + 1
+			var i = 0
+			while true:
+				var current_line_num = start_of_section + i
+				if current_line_num >= get_line_count(): break
+
+				var line = get_line(current_line_num)
+				if line.begins_with("["): break
+
+				if line.lstrip(" ").begins_with(";") or line.strip_edges().empty():
+					i += 1
+					continue
+				
+				var delimiter = _detect_delimiter(current_line_num, current_line_num + 1)
+				var parsed_line = _split_and_clean(line, delimiter)
+				
+				if parsed_line.size() < 6 or int(parsed_line[0]) in balls_to_exclude:
+					i += 1
+					continue
+
+				var color = parsed_line[5]
+				var updates = {}
+
+				if recolor_info.has(color):
+					updates[5] = recolor_info[color]
+
+				if not updates.empty():
+					var final_line = _update_fields(parsed_line, updates, delimiter)
+					set_line(current_line_num, final_line)
+
+				i += 1
+
 	if all_recolor_info.lines_on:
 		var section_find = search('[Linez]', 0, 0, 0)
-		var start_of_section = section_find[SEARCH_RESULT_LINE] + 1
-		var i = 0
-		while true:
-			var line = get_line(start_of_section + i).lstrip(" ")
-			# ignore comments for now
-			if line.begins_with("[") or line.empty() or i > get_line_count():
-				break
+		if section_find:
+			var start_of_section = section_find[SEARCH_RESULT_LINE] + 1
+			var i = 0
+			while true:
+				var current_line_num = start_of_section + i
+				if current_line_num >= get_line_count(): break
+				
+				var line = get_line(current_line_num)
+				if line.begins_with("["): break
+				
+				if line.lstrip(" ").begins_with(";") or line.strip_edges().empty():
+					i += 1
+					continue
 
-			# var parsed_line = r.search_all(line)
-			var delimiters = [", ", ",", "\t", " "]
-			var parsed_line = []
-			for delim in delimiters:
-				if line.split(delim).size() > 2:
-					parsed_line = line.split(delim, false)
-					break
+				var delimiter = _detect_delimiter(current_line_num, current_line_num + 1)
+				var parsed_line = _split_and_clean(line, delimiter)
+				
+				if parsed_line.size() < 6:
+					i += 1
+					continue
+				
+				var mainColor = parsed_line[3]
+				var lColor = parsed_line[4]
+				var rColor = parsed_line[5]
+				var updates = {}
+				
+				if recolor_info.has(mainColor):
+					updates[3] = recolor_info[mainColor]
+				
+				if recolor_info.has(lColor):
+					updates[4] = recolor_info[lColor]
+				
+				if recolor_info.has(rColor):
+					updates[5] = recolor_info[rColor]
+				
+				if not updates.empty():
+					var final_line = _update_fields(parsed_line, updates, delimiter)
+					set_line(current_line_num, final_line)
 
-			var mainColor = parsed_line[3]
-			var lColor = parsed_line[4]
-			var rColor = parsed_line[5]
-			if recolor_info.has(mainColor) or recolor_info.has(lColor) or recolor_info.has(rColor):
-				var n = 0
-				var final_line = ""
-				for item in parsed_line:
-					if n == 3 and recolor_info.has(mainColor):
-						final_line += recolor_info[mainColor] + " "
-					elif n == 4 and recolor_info.has(lColor):
-						final_line += recolor_info[lColor] + " "
-					elif n == 5 and recolor_info.has(rColor):
-						final_line += recolor_info[rColor] + " "
-					else:
-						final_line += item + " "
-					n += 1
-				set_line(start_of_section + i, final_line)
-			i += 1
+				i += 1
+				
 	save_file()
 
 func _on_ToolsMenu_move_head(x, y, z):

--- a/scenes/editor/LnzTextEdit.gd
+++ b/scenes/editor/LnzTextEdit.gd
@@ -2238,46 +2238,28 @@ func get_project_ball_section() -> Array:
 			comment = line.substr(line.find(";") + 1).strip_edges()
 			line = line.substr(0, line.find(";")).strip_edges()
 
-		# Now, we try to split the line using multiple possible delimiters
-		var parts = []
-		
-		# Option 1: Try splitting by comma
-		var comma_parts = line.split(",", false)
-		if comma_parts.size() >= 3:
-			parts = comma_parts
-		else:
-			# Option 2: Try splitting by tab
-			var tab_parts = line.split("\t", false)
-			if tab_parts.size() >= 3:
-				parts = tab_parts
-			else:
-				# Option 3: Try splitting by space
-				var space_parts = line.split(" ", false)
-				if space_parts.size() >= 3:
-					parts = space_parts
-		
-		# Clean up the parts by stripping whitespace
-		for j in range(parts.size()):
-			parts[j] = parts[j].strip_edges()
-			
-		# Proceed only if we successfully got a valid number of parts
-		if parts.size() == 3:
-			var amount = int(parts[2])
-			projections.append({
-				"fixed_ball": int(parts[0]),
-				"project_ball": int(parts[1]),
-				"min_projection": amount - 50,
-				"max_projection": amount + 50,
-				"comment": comment
-			})
-		elif parts.size() >= 4:
-			projections.append({
-				"fixed_ball": int(parts[0]),
-				"project_ball": int(parts[1]),
-				"min_projection": int(parts[2]),
-				"max_projection": int(parts[3]),
-				"comment": comment
-			})
+		var parts = _split_and_clean(line)
+		if parts.empty():
+			continue
+
+		if parts.size() >= 3:
+			if parts.size() == 3:
+				var amount = int(parts[2])
+				projections.append({
+					"fixed_ball": int(parts[0]),
+					"project_ball": int(parts[1]),
+					"min_projection": amount - 50,
+					"max_projection": amount + 50,
+					"comment": comment
+				})
+			elif parts.size() >= 4:
+				projections.append({
+					"fixed_ball": int(parts[0]),
+					"project_ball": int(parts[1]),
+					"min_projection": int(parts[2]),
+					"max_projection": int(parts[3]),
+					"comment": comment
+				})
 	return projections
 
 func write_project_ball_section(projections: Array):

--- a/scenes/editor/LnzTextEdit.gd
+++ b/scenes/editor/LnzTextEdit.gd
@@ -150,49 +150,55 @@ func _get_section_bounds(section_tag: String) -> Dictionary:
 	return {"start": start_line, "end": end_line}
 
 func _detect_delimiter(start_line: int, end_line: int) -> String:
-	for i in range(end_line - 1, start_line - 1, -1):
+	var delim_counts = {", ": 0, ",": 0, "\t": 0, " ": 0}
+	var lines_scanned = 0
+	for i in range(start_line, end_line):
 		var line = get_line(i).strip_edges()
-		if line == "" or line.begins_with(";"):
+		if line.empty() or line.begins_with(";"):
 			continue
-		if line.find("\t") != -1:
-			return "\t"
-		elif line.find(", ") != -1:
-			return ", "
-		elif line.find(",") != -1:
-			return ","
-		else:
-			return " "
-	return " "
+		lines_scanned += 1
 
-func _split_and_clean(line: String) -> Array:
-	# First, handle the common case of lines with comments
+		if line.find(", ") != -1:
+			delim_counts[", "] += 1
+		elif line.find(",") != -1:
+			delim_counts[","] += 1
+		elif line.find("\t") != -1:
+			delim_counts["\t"] += 1
+		elif line.find(" ") != -1:
+			if line.split(" ", false).size() > 1:
+				delim_counts[" "] += 1
+
+	if lines_scanned == 0:
+		return " "
+
+	var most_frequent_delim = " "
+	var max_count = 0
+	for delim in [", ", ",", "\t", " "]:
+		if delim_counts[delim] > max_count:
+			max_count = delim_counts[delim]
+			most_frequent_delim = delim
+
+	return most_frequent_delim
+
+func _split_and_clean(line: String, p_delimiter: String = "") -> Array:
 	var line_parts = line.split(";")
 	var data_part = line_parts[0].strip_edges()
 
-	# Now, try different delimiters on the data part
-	var delimiters = [", ", ",", "\t", " "]
-	for delim in delimiters:
-		var parts = data_part.split(delim, false)
-		
-		# Check if the split was successful (at least 2 parts for our case)
-		# The minimum size for a valid line is 2 (fixed_ball, project_ball),
-		# and later the code checks for 3 or 4.
-		if parts.size() >= 2:
-			var cleaned_parts = []
-			var valid_split = true
-			for part in parts:
-				var cleaned_part = part.strip_edges()
-				if cleaned_part.empty() and not (part.empty() and delim == " "):
-					# If a part becomes empty after stripping, but the original wasn't,
-					# it suggests the delimiter wasn't right (e.g., "1,,2" with a space delim)
-					valid_split = false
-					break
-				cleaned_parts.append(cleaned_part)
-			
-			if valid_split:
-				return cleaned_parts
-				
-	return []
+	var delimiter = p_delimiter
+	if delimiter == "":
+		if data_part.find(", ") != -1: delimiter = ", "
+		elif data_part.find(",") != -1: delimiter = ","
+		elif data_part.find("\t") != -1: delimiter = "\t"
+		else: delimiter = " "
+
+	var parts = data_part.split(delimiter, false)
+	var cleaned_parts = []
+	for part in parts:
+		var cleaned_part = part.strip_edges()
+		if not cleaned_part.empty():
+			cleaned_parts.append(cleaned_part)
+
+	return cleaned_parts
 
 func _update_fields(parts: Array, updates: Dictionary, sep: String) -> String:
 	var new_parts = []
@@ -201,7 +207,15 @@ func _update_fields(parts: Array, updates: Dictionary, sep: String) -> String:
 			new_parts.append(updates[i])
 		else:
 			new_parts.append(parts[i])
-	return new_parts.join(sep)
+	return _join_array(new_parts, sep)
+
+func _join_array(parts: Array, delimiter: String) -> String:
+	var result = ""
+	for i in range(parts.size()):
+		result += str(parts[i])
+		if i < parts.size() - 1:
+			result += delimiter
+	return result
 
 func _for_each_line_in_section(tag: String, callback):
 	var bounds = _get_section_bounds(tag)
@@ -595,7 +609,7 @@ func _on_Node_line_created(start_ball, end_ball):
 	var line_updated = false
 	for i in range(start_line, end_line):
 		var line = get_line(i).strip_edges()
-		if line.empty() or line.begins_with(";"):
+		if line.empty() or line == "" or line.begins_with(";"):
 			continue
 
 		var parts = _split_and_clean(line)
@@ -2392,6 +2406,8 @@ func _on_Node_ball_resized(ball_no: int, size_dif: int):
 			delim = "\t"
 		elif line.find(", ") != -1:
 			delim = ", "
+		elif line.find(",\t") != -1:
+			delim = ",\t"
 		elif line.find(",") != -1:
 			delim = ","
 		else:

--- a/scenes/editor/PetViewContainer.gd
+++ b/scenes/editor/PetViewContainer.gd
@@ -608,7 +608,7 @@ func get_ball_under_mouse(screen_pos: Vector2):
 	var to = from + camera.project_ray_normal(screen_pos) * 10000
 
 	var space_state = camera.get_world().direct_space_state
-	var result = space_state.intersect_ray(from, to, [], 0x7FFFFFFF, false, true)
+	var result = space_state.intersect_ray(from, to, [], 1, false, true)
 
 	if result and result.collider:
 		var parent = result.collider.get_parent()

--- a/scenes/editor/PresetSettings.gd
+++ b/scenes/editor/PresetSettings.gd
@@ -10,10 +10,8 @@ onready var pitch_spinbox = find_node("PitchSpinBox")
 onready var yaw_spinbox = find_node("YawSpinBox")
 
 const PaintBallData = preload("res://data_classes/paintball_data.gd")
-var r = RegEx.new()
 
 func _ready():
-	r.compile("[-.\\d]+")
 	find_node("EyedropperToggle").connect("toggled", self, "_on_EyedropperToggle_toggled")
 	set_paintballz_button.connect("pressed", self, "_on_SetPaintballzButton_pressed")
 
@@ -69,6 +67,20 @@ func show():
 func hide():
 	$Panel.hide()
 
+func _split_and_clean_paintball(line: String) -> Array:
+	var line_parts = line.split(";", false, 1)
+	var data_part = line_parts[0].strip_edges()
+
+	var delimiters = [", ", ",", "\t", " "]
+	for delim in delimiters:
+		var parts = data_part.split(delim, false)
+		if parts.size() >= 11:
+			var cleaned_parts = []
+			for part in parts:
+				cleaned_parts.append(part.strip_edges())
+			return cleaned_parts
+	return []
+
 func _on_SetPaintballzButton_pressed():
 	var text = paintballz_text_edit.text
 	var lines = text.split("\n")
@@ -77,23 +89,26 @@ func _on_SetPaintballzButton_pressed():
 	for line in lines:
 		if line.empty() or line.begins_with(";") or line.begins_with("#") or line.begins_with("["):
 			continue
-		var parsed = r.search_all(line)
-		if parsed.size() < 11:
+
+		var parts = _split_and_clean_paintball(line)
+		if parts.empty():
+			printerr("Could not parse paintball preset line: ", line)
 			continue
 
 		var item = paintballz_tree.create_item(root)
-		item.set_text(0, parsed[0].get_string())
-		item.set_text(1, parsed[1].get_string())
-		item.set_text(2, parsed[2].get_string())
-		item.set_text(3, parsed[3].get_string())
-		item.set_text(4, parsed[4].get_string())
-		item.set_text(5, parsed[5].get_string())
-		item.set_text(6, parsed[6].get_string())
-		item.set_text(7, parsed[7].get_string())
-		item.set_text(8, parsed[8].get_string())
-		item.set_text(9, parsed[10].get_string()) # there is a gap in the lnz format
-		if parsed.size() > 11:
-			item.set_text(10, parsed[11].get_string())
+		item.set_text(0, parts[0]) # Base
+		item.set_text(1, parts[1]) # Size
+		item.set_text(2, parts[2]) # Pos X
+		item.set_text(3, parts[3]) # Pos Y
+		item.set_text(4, parts[4]) # Pos Z
+		item.set_text(5, parts[5]) # Color
+		item.set_text(6, parts[6]) # Outline Color
+		item.set_text(7, parts[7]) # Fuzz
+		item.set_text(8, parts[8]) # Outline
+		item.set_text(9, parts[10]) # Texture (skip group at index 9)
+
+		if parts.size() > 11:
+			item.set_text(10, parts[11]) # Anchored
 		else:
 			item.set_text(10, "0")
 

--- a/scenes/editor/PresetSettings.tscn
+++ b/scenes/editor/PresetSettings.tscn
@@ -1,9 +1,11 @@
-[gd_scene load_steps=6 format=2]
+[gd_scene load_steps=7 format=2]
 
 [ext_resource path="res://scenes/editor/PresetSettings.gd" type="Script" id=1]
 [ext_resource path="res://resources/styles/styleboxflat_button_normal.tres" type="StyleBox" id=2]
 [ext_resource path="res://resources/fonts/pixel_maz.ttf" type="DynamicFontData" id=3]
 [ext_resource path="res://scenes/editor/DraggablePanel.gd" type="Script" id=4]
+
+[sub_resource type="ButtonGroup" id=2]
 
 [sub_resource type="DynamicFont" id=1]
 size = 30
@@ -101,13 +103,12 @@ margin_top = 111.0
 margin_right = 420.0
 margin_bottom = 140.0
 
-[node name="SizeButtonGroup" type="Node" parent="Panel/VBoxContainer/SizeOptionsContainer"]
-
 [node name="SizeSetToggle" type="CheckBox" parent="Panel/VBoxContainer/SizeOptionsContainer"]
 margin_right = 137.0
 margin_bottom = 29.0
 size_flags_horizontal = 3
 custom_fonts/font = SubResource( 1 )
+group = SubResource( 2 )
 text = "Set"
 
 [node name="SizeSumToggle" type="CheckBox" parent="Panel/VBoxContainer/SizeOptionsContainer"]
@@ -116,6 +117,7 @@ margin_right = 278.0
 margin_bottom = 29.0
 size_flags_horizontal = 3
 custom_fonts/font = SubResource( 1 )
+group = SubResource( 2 )
 text = "Sum"
 
 [node name="SizeTrueToggle" type="CheckBox" parent="Panel/VBoxContainer/SizeOptionsContainer"]
@@ -125,6 +127,7 @@ margin_bottom = 29.0
 size_flags_horizontal = 3
 custom_fonts/font = SubResource( 1 )
 pressed = true
+group = SubResource( 2 )
 text = "True"
 
 [node name="HBoxContainer2" type="HBoxContainer" parent="Panel/VBoxContainer"]

--- a/scenes/editor/ProjectSettings.gd
+++ b/scenes/editor/ProjectSettings.gd
@@ -265,7 +265,6 @@ func _on_RandomizeBodyButton_pressed():
 	emit_signal("randomize_body_proportions", settings)
 
 func _on_ApplyButton_pressed():
-	var lnz_projections = []
 	var root = projections_tree.get_root()
 	if not root:
 		return
@@ -279,44 +278,59 @@ func _on_ApplyButton_pressed():
 	elif species == KeyBallsData.Species.BABY:
 		symmetry_dict = KeyBallsData.baby_body_part_symmetry
 
+	var lnz_projections = []
+	
+	# Scan to see which projections already exist
+	var existing_pairs = {}
 	var item = root.get_children()
 	while item:
+		var fixed = item.get_text(0).to_int()
+		var project = item.get_text(1).to_int()
+		var key = Vector2(min(fixed, project), max(fixed, project))
+		existing_pairs[key] = true
+		item = item.get_next()
+
+	# Build list of projections
+	item = root.get_children()
+	while item:
+		var fixed_ball = item.get_text(0).to_int()
+		var project_ball = item.get_text(1).to_int()
+		
 		var proj = {
-			"fixed_ball": item.get_text(0).to_int(),
-			"project_ball": item.get_text(1).to_int(),
+			"fixed_ball": fixed_ball,
+			"project_ball": project_ball,
 			"value": item.get_text(4).to_int(),
 			"comment": item.get_text(7)
 		}
 		lnz_projections.append(proj)
 
-		if item.is_checked(6) and symmetry_dict: # if mirrored
-			var mirrored_fixed = KeyBallsData.get_mirrored_ball(proj.fixed_ball, symmetry_dict)
-			var mirrored_projected = KeyBallsData.get_mirrored_ball(proj.project_ball, symmetry_dict)
+		# If mirrored, create the mirrored version and add ONLY if it doesn't already exist as a separate entry
+		if item.is_checked(6) and symmetry_dict:
+			var mirrored_fixed_raw = KeyBallsData.get_mirrored_ball(proj.fixed_ball, symmetry_dict)
+			var mirrored_project_raw = KeyBallsData.get_mirrored_ball(proj.project_ball, symmetry_dict)
 
-			if mirrored_fixed != -1 or mirrored_projected != -1:
-				var new_fixed = mirrored_fixed
-				if new_fixed == -1:
-					new_fixed = proj.fixed_ball
+			# If a ball doesn't have a mirror, it mirrors to itself
+			var mirrored_fixed = mirrored_fixed_raw if mirrored_fixed_raw != -1 else proj.fixed_ball
+			var mirrored_project = mirrored_project_raw if mirrored_project_raw != -1 else proj.project_ball
+			
+			# Check if the mirrored pair is the same as the original
+			var is_self_mirrored = (mirrored_fixed == proj.fixed_ball) and (mirrored_project == proj.project_ball)
+			
+			if not is_self_mirrored:
+				var mirror_key = Vector2(min(mirrored_fixed, mirrored_project), max(mirrored_fixed, mirrored_project))
+				
+				# If this mirrored pair was NOT found in our initial scan, add it
+				if not existing_pairs.has(mirror_key):
+					var mirrored_proj = {
+						"fixed_ball": mirrored_fixed,
+						"project_ball": mirrored_project,
+						"value": proj.value,
+						"comment": proj.comment
+					}
+					lnz_projections.append(mirrored_proj)
+					# Add it to the set so it doesn't get added again by another mirror check
+					existing_pairs[mirror_key] = true
 
-				var new_projected = mirrored_projected
-				if new_projected == -1:
-					new_projected = proj.project_ball
-
-				var mirrored_proj = {
-					"fixed_ball": new_projected,
-					"project_ball": new_fixed,
-					"value": proj.value,
-					"comment": proj.comment
-				}
-
-				if not (mirrored_proj.fixed_ball == proj.fixed_ball and mirrored_proj.project_ball == proj.project_ball):
-					var is_duplicate = false
-					for p in lnz_projections:
-						if p.fixed_ball == mirrored_proj.fixed_ball and p.project_ball == mirrored_proj.project_ball:
-							is_duplicate = true
-							break
-					if not is_duplicate:
-						lnz_projections.append(mirrored_proj)
 		item = item.get_next()
 
 	emit_signal("apply_projections", lnz_projections)

--- a/scenes/editor/ProjectSettings.gd
+++ b/scenes/editor/ProjectSettings.gd
@@ -20,6 +20,7 @@ func _ready():
 	find_node("MoveDownButton").connect("pressed", self, "_on_MoveDownButton_pressed")
 	projections_tree.connect("item_edited", self, "_on_ProjectionsTree_item_edited")
 	projections_tree.connect("button_pressed", self, "_on_ProjectionsTree_button_pressed")
+	projections_tree.connect("column_title_pressed", self, "_on_ProjectionsTree_column_title_pressed")
 
 	# Setup Tree
 	projections_tree.set_column_titles_visible(true)
@@ -186,18 +187,66 @@ func _on_RandomizeProjectionsButton_pressed():
 	if not root:
 		return
 
+	var species = KeyBallsData.species
+	var symmetry_dict = null
+	if species == KeyBallsData.Species.DOG:
+		symmetry_dict = KeyBallsData.dog_body_part_symmetry
+	elif species == KeyBallsData.Species.CAT:
+		symmetry_dict = KeyBallsData.cat_body_part_symmetry
+	elif species == KeyBallsData.Species.BABY:
+		symmetry_dict = KeyBallsData.baby_body_part_symmetry
+
+	var processed_items = []
+	var all_items = []
 	var item = root.get_children()
 	while item:
-		if not item.is_checked(5): # if not locked
-			var min_proj = item.get_text(2).to_int()
-			var max_proj = item.get_text(3).to_int()
+		all_items.append(item)
+		item = item.get_next()
+
+	for item_a in all_items:
+		if item_a in processed_items:
+			continue
+
+		if not item_a.is_checked(5): # if not locked
+			var min_proj = item_a.get_text(2).to_int()
+			var max_proj = item_a.get_text(3).to_int()
 			var random_val = 0
 			if min_proj < max_proj:
 				random_val = randi() % (max_proj - min_proj + 1) + min_proj
 			else:
 				random_val = min_proj
-			item.set_text(4, str(random_val))
-		item = item.get_next()
+			item_a.set_text(4, str(random_val))
+
+		processed_items.append(item_a)
+
+		if not symmetry_dict:
+			continue
+
+		# Find and update the mirror
+		var fixed_a = item_a.get_text(0).to_int()
+		var proj_a = item_a.get_text(1).to_int()
+
+		var mirrored_fixed = KeyBallsData.get_mirrored_ball(fixed_a, symmetry_dict)
+		var mirrored_proj = KeyBallsData.get_mirrored_ball(proj_a, symmetry_dict)
+
+		if mirrored_fixed == -1: mirrored_fixed = fixed_a
+		if mirrored_proj == -1: mirrored_proj = proj_a
+
+		for item_b in all_items:
+			if item_b in processed_items:
+				continue
+
+			var fixed_b = item_b.get_text(0).to_int()
+			var proj_b = item_b.get_text(1).to_int()
+
+			var is_mirror = (fixed_b == mirrored_fixed and proj_b == mirrored_proj)
+			var is_swapped_mirror = (fixed_b == mirrored_proj and proj_b == mirrored_fixed)
+
+			if is_mirror or is_swapped_mirror:
+				if not item_b.is_checked(5): # if not locked
+					item_b.set_text(4, item_a.get_text(4))
+				processed_items.append(item_b)
+				break
 
 func _on_RandomizeBodyButton_pressed():
 	var settings = {
@@ -254,8 +303,8 @@ func _on_ApplyButton_pressed():
 					new_projected = proj.project_ball
 
 				var mirrored_proj = {
-					"fixed_ball": new_fixed,
-					"project_ball": new_projected,
+					"fixed_ball": new_projected,
+					"project_ball": new_fixed,
 					"value": proj.value,
 					"comment": proj.comment
 				}
@@ -280,3 +329,28 @@ func show():
 
 func hide():
 	panel.hide()
+
+func _on_ProjectionsTree_column_title_pressed(column_index):
+	if column_index == 5 or column_index == 6: # Lock or Mirror
+		var root = projections_tree.get_root()
+		if not root:
+			return
+
+		var item = root.get_children()
+		if not item:
+			return
+
+		# Determine target state: if any are unchecked, check all. Otherwise, uncheck all.
+		var target_state = false
+		var current_item = item
+		while current_item:
+			if not current_item.is_checked(column_index):
+				target_state = true
+				break
+			current_item = current_item.get_next()
+
+		# Apply the target state to all items
+		current_item = item
+		while current_item:
+			current_item.set_checked(column_index, target_state)
+			current_item = current_item.get_next()


### PR DESCRIPTION
- If no `[Species]`, set species from `[Default Linez File]`
- Don't duplicate `[Project Ball]` entries when mirroring pairs that already exist in queue
- Use delimiter parsing for color swap (but still not resolved is handling of mixed delimiters, e.g., `50, 2,-1,0, 54` where mixed commas and comma-spaces... may need better solution)
- Prevent paintball visuals from blocking paintball placement during Paintball Mode via collision layer